### PR TITLE
Add CREATE_DREAM mutation into DreamInput functionality and moved tag…

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -6,7 +6,7 @@ import DreamInput from "../DreamInput/DreamInput";
 import DreamList from "../DreamList/DreamList";
 import NotFound from "../NotFound/NotFound";
 import Nav from "../Nav/Nav";
-import GET_USER from "../../queries";
+import { GET_USER  } from "../../queries";
 import { useLazyQuery } from "@apollo/client";
 
 const App = () => {
@@ -38,7 +38,7 @@ const App = () => {
             render={() => (
               <>
                 <Nav />
-                <DreamInput />
+                <DreamInput user={user}/>
               </>
             )}
           />

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,62 @@
+import chroma from "chroma-js";
+import { mockEmotions, mockTags } from './mock-data'
+
+export const generateColor = () => chroma.random().css();
+
+export const getEmotionOptions = () =>
+  mockEmotions.data.emotions.map((emotion) => ({
+    value: emotion,
+    label: emotion,
+    color: generateColor(),
+  }));
+
+export const getTagOptions = () =>
+  mockTags.data.tags.map((tag) => ({
+    value: tag,
+    label: tag,
+    color: generateColor(),
+  }));
+
+export const colourStyles = {
+  control: (styles) => ({ ...styles, backgroundColor: "white" }),
+  option: (styles, { data, isDisabled, isFocused, isSelected }) => {
+    const color = data.color;
+    return {
+      ...styles,
+      backgroundColor: isDisabled
+        ? null
+        : isSelected
+        ? color
+        : isFocused
+        ? chroma(color).alpha(0.1).css()
+        : null,
+      color: isDisabled
+        ? "#ccc"
+        : isSelected
+        ? chroma.contrast(color, "white") > 2
+          ? "white"
+          : "black"
+        : color,
+      cursor: isDisabled ? "not-allowed" : "default",
+    };
+  },
+  multiValue: (styles, { data }) => {
+    const color = data.color;
+    return {
+      ...styles,
+      backgroundColor: color,
+    };
+  },
+  multiValueLabel: (styles, { data }) => ({
+    ...styles,
+    color: "white",
+  }),
+  multiValueRemove: (styles, { data }) => ({
+    ...styles,
+    color: "white",
+    ":hover": {
+      backgroundColor: data.color,
+      color: "white",
+    },
+  }),
+};

--- a/src/queries.js
+++ b/src/queries.js
@@ -1,8 +1,9 @@
 import { gql } from "@apollo/client";
 
-  const GET_USER = gql`
+  export const GET_USER = gql`
   query ($id: ID!) {
     user(id: $id) {
+      id
       name
       email
       dreams {
@@ -22,4 +23,20 @@ import { gql } from "@apollo/client";
   `
 ;
 
-export default GET_USER;
+export const CREATE_DREAM = gql`
+  mutation CreateDream($input: CreateDreamInput!) {
+    createDream(input: $input) {
+      id
+      dreamDate
+      title
+      description
+      emotions {
+        name
+      }
+      tags {
+        name
+      }
+      lucidity
+    }
+  }
+`;


### PR DESCRIPTION
…/emotion styling into seperate options file

# Description

- Incorporated CREATE_DREAM mutation into DreamInput. Tested with successful responses, still need to handle errors
- Added CREATE_DREAM to queries file so import for GET_USER on app.js will be different, FYI
- moved styling for tags and emotions into options.js for easier readability of DreamInput component

## Type of change

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [x]  Refactoring

# Related Issues:

- closes #46 
- and/or related to #<issue number>
