### PR TITLE
Add width to mobile view

### DIFF
--- a/src/Components/DreamInput/DreamInput.css
+++ b/src/Components/DreamInput/DreamInput.css
@@ -264,6 +264,7 @@
 @media screen and (max-width: 500px) {
   .form-container {
     height: 90%;
+    width: 80%;
   }
 
   .multi-select {


### PR DESCRIPTION
Added a different width for mobile view in the DreamInput component so the .form-container takes up most of the screen at 80%
Before:
![Screenshot 2023-07-10 at 1 14 14 PM](https://github.com/Inner-Worlds/inner-worlds-ui/assets/114712752/33825ec5-bd14-4d32-a698-1c699bb1857d)

After:
![Screenshot 2023-07-10 at 1 14 27 PM](https://github.com/Inner-Worlds/inner-worlds-ui/assets/114712752/0f6cb03c-982f-4b12-85fa-6aae776bb6bb)
